### PR TITLE
Enable to build standalone / Remove self reference (1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ This plugin needs to be added via the standard plugin mechanism with this builds
 
     buildscript {
         repositories {
-            maven { url "https://github.com/layerhq/releases-gradle/raw/master/releases" }
+            maven { url "https://github.com/umorigu/gradle-git-repo-plugin/raw/release/releases" }
         }
         dependencies {
-            classpath group: 'com.layer', name: 'git-repo-plugin', version: '1.0.0'
+            classpath group: 'com.layer', name: 'git-repo-plugin', version: '1.0.1'
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,5 @@
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
-apply plugin: 'git-repo'
-
-buildscript {
-     repositories {
-         maven { url "https://github.com/layerhq/releases-gradle/raw/master/releases" }
-     }
-     dependencies {
-         classpath group: 'com.layer', name: 'git-repo-plugin', version: '1.0.0'
-     }
-}
 
 apply from: "$rootDir/version.gradle"
 


### PR DESCRIPTION
* Enable to build standalone (Remove self reference)
* Version 1.0.1

Make maven files:

```
gradle -Porg=umorigu -Prepo=gradle-git-repo-plugin publish
```
